### PR TITLE
fixes #2, #3, #4

### DIFF
--- a/Ue4Export/Exporter.cs
+++ b/Ue4Export/Exporter.cs
@@ -26,6 +26,7 @@ using CUE4Parse.UE4.Shaders;
 using CUE4Parse.UE4.Versions;
 using CUE4Parse.UE4.Wwise;
 using CUE4Parse_Conversion.Textures;
+using CUE4Parse_Conversion.Textures.BC;
 using Newtonsoft.Json;
 using SkiaSharp;
 using System.Text;
@@ -72,6 +73,15 @@ namespace Ue4Export
 
 		public bool Export()
 		{
+			var detexPath = Path.Combine(AppContext.BaseDirectory, DetexHelper.DLL_NAME);
+			if (File.Exists(detexPath))
+			{
+				mLogger?.Log(LogLevel.Important, $"Initializing detex at {detexPath}.");
+				DetexHelper.Initialize(detexPath);
+			}
+			else
+				mLogger?.Log(LogLevel.Important, $"Detex DLL not found, texture conversion is unavailable.");
+
 			bool success = true;
 
 			using (var provider = new DefaultFileProvider(new DirectoryInfo(mOptions.AssetsDirectory), mOptions.AssetSearchOption, null, null))
@@ -330,6 +340,7 @@ namespace Ue4Export
 						byte[] data = provider.Files[assetPath].Read();
 
 						string outPath = Path.Combine(mOptions.OutputDirectory, assetPath);
+						if (mOptions.SkipExisting && File.Exists(outPath)) break;
 						Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
 						File.WriteAllBytes(outPath, data);
 
@@ -347,6 +358,7 @@ namespace Ue4Export
 						foreach (var pair in raw)
 						{
 							string outPath = Path.Combine(mOptions.OutputDirectory, pair.Key);
+							if (mOptions.SkipExisting && File.Exists(outPath)) continue;
 							Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
 							File.WriteAllBytes(outPath, pair.Value);
 						}
@@ -372,6 +384,7 @@ namespace Ue4Export
 				outPath = Path.Combine(mOptions.OutputDirectory, assetPath);
 			}
 
+			if (mOptions.SkipExisting && File.Exists(outPath)) return true;
 			Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
 
 			switch (ext)
@@ -499,7 +512,8 @@ namespace Ue4Export
 
 							mLogger?.Log(LogLevel.Information, $"  Saving texture {texture.Name}");
 
-							string outPath = Path.Combine(mOptions.OutputDirectory, $"{ConvertAssetPath(texture.GetPathName())}.png");
+							string outPath = Path.Combine(mOptions.OutputDirectory, Path.ChangeExtension(assetPath, ".png"));
+							if (mOptions.SkipExisting && File.Exists(outPath)) return true;
 							success &= WriteTexture(bitmap, SKEncodedImageFormat.Png, outPath);
 						}
 
@@ -524,6 +538,7 @@ namespace Ue4Export
 						byte[] data = provider.SaveAsset(assetPath);
 
 						string outPath = Path.Combine(mOptions.OutputDirectory, assetPath);
+						if (mOptions.SkipExisting && File.Exists(outPath)) return true;
 
 						SKEncodedImageFormat format;
 						switch (ext)

--- a/Ue4Export/Exporter.cs
+++ b/Ue4Export/Exporter.cs
@@ -74,14 +74,14 @@ namespace Ue4Export
 		public bool Export()
 		{
 			var detexPath = Path.Combine(AppContext.BaseDirectory, DetexHelper.DLL_NAME);
-			if (File.Exists(detexPath))
+
+			if (!File.Exists(detexPath))
 			{
 				mLogger?.Log(LogLevel.Important, $"Initializing detex at {detexPath}.");
-				DetexHelper.Initialize(detexPath);
+				DetexHelper.LoadDll(detexPath);
 			}
-			else
-				mLogger?.Log(LogLevel.Important, $"Detex DLL not found, texture conversion is unavailable.");
 
+			DetexHelper.Initialize(detexPath);
 			bool success = true;
 
 			using (var provider = new DefaultFileProvider(new DirectoryInfo(mOptions.AssetsDirectory), mOptions.AssetSearchOption, null, null))

--- a/Ue4Export/Options.cs
+++ b/Ue4Export/Options.cs
@@ -73,6 +73,11 @@ namespace Ue4Export
 		/// </summary>
 		public bool IsSilent { get; set; }
 
+		/// <summary>
+		/// Whether to skip existing files
+		/// </summary>
+		public bool SkipExisting { get; set; }
+
 		private Options()
 		{
 			AssetsDirectory = null!;
@@ -83,6 +88,7 @@ namespace Ue4Export
 			AssetSearchOption = SearchOption.AllDirectories;
 			IsQuiet = false;
 			IsSilent = false;
+			SkipExisting = false;
 		}
 
 		/// <summary>
@@ -149,6 +155,9 @@ namespace Ue4Export
 							break;
 						case "silent":
 							instance.IsSilent = true;
+							break;
+						case "skip-existing":
+							instance.SkipExisting = true;
 							break;
 						default:
 							logger.LogError($"Unrecognized argument '{args[i]}'");
@@ -303,6 +312,7 @@ namespace Ue4Export
 			logger.Log(logLevel, $"{indent}  Mix output        {MixOutput}");
 			logger.Log(logLevel, $"{indent}  Mappings path     {MappingsPath??"[None]"}");
 			logger.Log(logLevel, $"{indent}  AES key           {(EncryptionKey is null ? "No" : "Yes")}");
+			logger.Log(logLevel, $"{indent}  Skip existing     {SkipExisting}");
 		}
 	}
 }

--- a/Ue4Export/Ue4Export.csproj
+++ b/Ue4Export/Ue4Export.csproj
@@ -36,11 +36,15 @@
   <Target Name="CopyLibs" AfterTargets="PostBuildEvent">
     <Copy SourceFiles="$(SolutionDir)lib\oo2core_9_win64.dll" DestinationFolder="$(TargetDir)" />
     <Copy SourceFiles="$(SolutionDir)lib\zlib-ng2.dll" DestinationFolder="$(TargetDir)" />
+    <Copy SourceFiles="..\CUE4Parse\CUE4Parse-Conversion\Resources\Detex.dll" DestinationFolder="$(TargetDir)" />
+    <Copy SourceFiles="..\CUE4Parse\CUE4Parse-Conversion\Resources\tegra_swizzle_x64.dll" DestinationFolder="$(TargetDir)" />
   </Target>
 
   <Target Name="PublishCopyLibs" AfterTargets="CopyFilesToOutputDirectory">
     <Copy SourceFiles="$(SolutionDir)lib\oo2core_9_win64.dll" DestinationFolder="$(PublishDir)" />
     <Copy SourceFiles="$(SolutionDir)lib\zlib-ng2.dll" DestinationFolder="$(PublishDir)" />
+    <Copy SourceFiles="..\CUE4Parse\CUE4Parse-Conversion\Resources\Detex.dll" DestinationFolder="$(PublishDir)" />
+    <Copy SourceFiles="..\CUE4Parse\CUE4Parse-Conversion\Resources\tegra_swizzle_x64.dll" DestinationFolder="$(PublishDir)" />
   </Target>
 
 </Project>

--- a/Ue4Export/Ue4Export.csproj
+++ b/Ue4Export/Ue4Export.csproj
@@ -36,15 +36,11 @@
   <Target Name="CopyLibs" AfterTargets="PostBuildEvent">
     <Copy SourceFiles="$(SolutionDir)lib\oo2core_9_win64.dll" DestinationFolder="$(TargetDir)" />
     <Copy SourceFiles="$(SolutionDir)lib\zlib-ng2.dll" DestinationFolder="$(TargetDir)" />
-    <Copy SourceFiles="..\CUE4Parse\CUE4Parse-Conversion\Resources\Detex.dll" DestinationFolder="$(TargetDir)" />
-    <Copy SourceFiles="..\CUE4Parse\CUE4Parse-Conversion\Resources\tegra_swizzle_x64.dll" DestinationFolder="$(TargetDir)" />
   </Target>
 
   <Target Name="PublishCopyLibs" AfterTargets="CopyFilesToOutputDirectory">
     <Copy SourceFiles="$(SolutionDir)lib\oo2core_9_win64.dll" DestinationFolder="$(PublishDir)" />
     <Copy SourceFiles="$(SolutionDir)lib\zlib-ng2.dll" DestinationFolder="$(PublishDir)" />
-    <Copy SourceFiles="..\CUE4Parse\CUE4Parse-Conversion\Resources\Detex.dll" DestinationFolder="$(PublishDir)" />
-    <Copy SourceFiles="..\CUE4Parse\CUE4Parse-Conversion\Resources\tegra_swizzle_x64.dll" DestinationFolder="$(PublishDir)" />
   </Target>
 
 </Project>

--- a/readme.md
+++ b/readme.md
@@ -229,6 +229,8 @@ Options
 
   --silent           No logging unless an error occurs.
 
+  --skip-existing    Skip existing files.
+
 Game engine versions
   Pass in the engine version that best matches the game being dumped. If the game has a
   specialized version, pass that in. Otherwise, pass in the engine version the game was


### PR DESCRIPTION
Tested and working.
In case you repack the files manually, these dlls should be placed next to exe (already added to publish):
CUE4Parse-Conversion\Resources\Detex.dll (block compression support, needed a patch to initialize)
CUE4Parse-Conversion\Resources\tegra_swizzle_x64.dll (morton code support, autoimports)